### PR TITLE
motion.so cannot be used without google

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -35,7 +35,7 @@ const DEVELOPER_DOMAINS = [
 ];
 
 const GOOGLE_APPS_SAAS = [
-  "cloudcraft.co", "draw.io", "bilth.com", "atlassian.net", "atlassian.com"
+  "cloudcraft.co", "draw.io", "bilth.com", "atlassian.net", "atlassian.com", "www.notion.so"
 ];
 
 GOOGLE_DOMAINS = GOOGLE_DOMAINS


### PR DESCRIPTION
The only option to login in https://www.notion.so is using Google SSO