### PR TITLE
Adding bitbucket.org to the list of allowed Google integrations; fixes issue #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Also an initial list of 3rd party integration apps was added (draw.io, etc).  So
 * bilth.com
 * atlassian.net
 * atlassian.com
+* bitbucket.org
 * www.notion.so
 
 Please [open an issue](https://github.com/NewAlexandria/contain-google/issues/new) for any that you find need support!

--- a/src/background.js
+++ b/src/background.js
@@ -40,7 +40,7 @@ const DEVELOPER_DOMAINS = [
 ];
 
 const GOOGLE_APPS_SAAS = [
-  "cloudcraft.co", "draw.io", "bilth.com", "atlassian.net", "atlassian.com", "www.notion.so"
+  "cloudcraft.co", "draw.io", "bilth.com", "atlassian.net", "atlassian.com", "bitbucket.org", "www.notion.so"
 ];
 
 GOOGLE_DOMAINS = GOOGLE_DOMAINS


### PR DESCRIPTION
Hello,

I'm an engineer at Atlassian and we had a customer that had trouble logging into bitbucket while using your extension. I grabbed the extension, confirmed that logging into bitbucket.org didn't work, and then tried to find a fix. Seeing as you had already added two Atlassian domains, it was really simple to add bitbucket.org to the list (which is another Atlassian domain, so I thought it was still in the spirit of your extension).

This PR adds bitbucket.org to the `GOOGLE_APPS_SAAS` variable, which allows bitbucket access to google during the log in flow. I also updated the README to reflect that change. This will fix issue #6.

I'd be happy to work with you if this needs other changes, but I have confirmed locally that the code change allows login to work on bitbucket.org again. Thanks for making and releasing this fork of the extension and I hope we can get this change out to AMO soon.